### PR TITLE
Fix roofline crash when device_count==1

### DIFF
--- a/software_model/transformer.py
+++ b/software_model/transformer.py
@@ -168,7 +168,7 @@ class TransformerBlockInitComputationTP(Operator):
             allreduce_latency = self.allreduce_mha.simulate(interconnect)
             allreduce_total_latency = allreduce_latency * 2
         else:
-            allreduce_total_latency = 0
+            allreduce_latency = 0
             allreduce_total_latency = 0
 
         # others


### PR DESCRIPTION
Fixes UnboundLocalError in roofline_model() for single-device runs by defining allreduce_latency=0 when device_count==1.

This unblocks ArchCopilot roofline mode producing a valid counter contract.